### PR TITLE
BUG: Don't write to the fs on module import.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+ignore = E203, E266, E501, W503
+exclude =
+  # Standard linting exemptions.
+  __pycache__,
+  .git,
+  *.pyc,
+  conf.py

--- a/ci/requirements-2.7-0.19.2.pip
+++ b/ci/requirements-2.7-0.19.2.pip
@@ -3,6 +3,7 @@ google-auth-oauthlib
 PyCrypto
 mock
 google-cloud-bigquery
+pyfakefs
 pytest
 pytest-cov
 codecov

--- a/ci/requirements-3.5-0.18.1.pip
+++ b/ci/requirements-3.5-0.18.1.pip
@@ -1,6 +1,7 @@
 google-auth==1.4.1
 google-auth-oauthlib==0.0.1
 google-cloud-bigquery==0.32.0
+pyfakefs
 pytest
 pytest-cov
 codecov

--- a/ci/requirements-3.6-0.20.1.conda
+++ b/ci/requirements-3.6-0.20.1.conda
@@ -1,6 +1,7 @@
 google-auth
 google-auth-oauthlib
 google-cloud-bigquery==0.32.0
+pyfakefs
 pytest
 pytest-cov
 codecov

--- a/ci/requirements-3.6-MASTER.pip
+++ b/ci/requirements-3.6-MASTER.pip
@@ -3,6 +3,7 @@ google-auth-oauthlib
 git+https://github.com/GoogleCloudPlatform/google-cloud-python.git#egg=version_subpkg&subdirectory=api_core
 git+https://github.com/GoogleCloudPlatform/google-cloud-python.git#egg=version_subpkg&subdirectory=core
 git+https://github.com/GoogleCloudPlatform/google-cloud-python.git#egg=version_subpkg&subdirectory=bigquery
+pyfakefs
 pytest
 pytest-cov
 codecov

--- a/pydata_google_auth/__init__.py
+++ b/pydata_google_auth/__init__.py
@@ -1,4 +1,3 @@
-
 from .auth import default
 from .auth import get_user_credentials
 from ._version import get_versions

--- a/pydata_google_auth/_version.py
+++ b/pydata_google_auth/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build

--- a/pydata_google_auth/auth.py
+++ b/pydata_google_auth/auth.py
@@ -19,7 +19,7 @@ from pydata_google_auth import cache
 logger = logging.getLogger(__name__)
 
 CLIENT_ID = (
-    "262006177488-3425ks60hkk80fssi9vpohv88g6q1iqd" ".apps.googleusercontent.com"
+    "262006177488-3425ks60hkk80fssi9vpohv88g6q1iqd.apps.googleusercontent.com"
 )
 CLIENT_SECRET = "JSF-iczmzEgbTR-XK-2xaWAc"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ google-cloud-bigquery
 nox-automation
 pandas
 pytest
+pyfakefs
 setuptools

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,56 @@
+"""Test module for pydata_google_auth.cache"""
+
+import json
+import os
+import os.path
+
+import pytest
+
+import google.oauth2.credentials
+from six.moves import reload_module
+
+
+@pytest.fixture
+def module_under_test():
+    from pydata_google_auth import cache
+
+    return cache
+
+
+def test_import_unwriteable_fs(module_under_test, monkeypatch):
+    """Test import with an unwritable filesystem.
+
+    See: https://github.com/pydata/pydata-google-auth/issues/10
+    """
+
+    def raise_unwriteable(path):
+        raise PermissionError()
+
+    monkeypatch.setattr(os.path, "exists", lambda _: False)
+    monkeypatch.setattr(os, "makedirs", raise_unwriteable)
+
+    reload_module(module_under_test)
+
+    assert module_under_test.NOOP is not None
+
+
+def test__save_user_account_credentials_wo_directory(module_under_test, fs):
+    """Directories should be created if they don't exist."""
+
+    credentials = google.oauth2.credentials.Credentials(
+        token="access_token",
+        refresh_token="refresh_token",
+        id_token="id_token",
+        token_uri="token_uri",
+        client_id="client_id",
+        client_secret="client_secret",
+        scopes=["scopes"],
+    )
+    path = "/home/username/.config/pydata/pydata_google_credentials.json"
+    assert not os.path.exists("/home/username/.config/pydata/")
+
+    module_under_test._save_user_account_credentials(credentials, path)
+
+    with open(path) as fp:
+        serialized_data = json.load(fp)
+    assert serialized_data["refresh_token"] == "refresh_token"

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.18
 
 """The Versioneer - like a rocketeer, but for versions.


### PR DESCRIPTION
Avoid writing to the filesystem when the module imports.
This prevents errors when the home directory is
unwriteable.

Closes https://github.com/pydata/pydata-google-auth/issues/10.

CC @PeterJCLaw 