### PR TITLE
BUG: Respect dirname and filename arguments in cache constructors

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+.. _changelog-0.1.3:
+
+0.1.3 / TBD
+-----------
+
+Bug Fixes
+^^^^^^^^^
+
+- Respect the ``dirname`` and ``filename`` arguments to the
+  :class:`~pydata_google_auth.cache.ReadWriteCredentialsCache` and
+  :class:`~pydata_google_auth.cache.WriteOnlyCredentialsCache` constructors.
+  (:issue:`16`, :issue:`17`)
+
 .. _changelog-0.1.2:
 
 0.1.2 / (2019-02-01)

--- a/pydata_google_auth/cache.py
+++ b/pydata_google_auth/cache.py
@@ -169,7 +169,7 @@ class ReadWriteCredentialsCache(CredentialsCache):
 
     def __init__(self, dirname=_DIRNAME, filename=_FILENAME):
         super(ReadWriteCredentialsCache, self).__init__()
-        self._path = _get_default_credentials_path(_DIRNAME, _FILENAME)
+        self._path = _get_default_credentials_path(dirname, filename)
 
     def load(self):
         """
@@ -215,7 +215,7 @@ class WriteOnlyCredentialsCache(CredentialsCache):
 
     def __init__(self, dirname=_DIRNAME, filename=_FILENAME):
         super(WriteOnlyCredentialsCache, self).__init__()
-        self._path = _get_default_credentials_path(_DIRNAME, _FILENAME)
+        self._path = _get_default_credentials_path(dirname, filename)
 
     def save(self, credentials):
         """

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -54,3 +54,31 @@ def test__save_user_account_credentials_wo_directory(module_under_test, fs):
     with open(path) as fp:
         serialized_data = json.load(fp)
     assert serialized_data["refresh_token"] == "refresh_token"
+
+
+def test_ReadWriteCredentialsCache_sets_path(module_under_test):
+    """ReadWriteCredentialsCache ctor should respect dirname and filename.
+
+    See: https://github.com/pydata/pydata-google-auth/issues/16
+    """
+    cache = module_under_test.ReadWriteCredentialsCache(
+        dirname="dirtest", filename="filetest.json"
+    )
+    path = os.path.normpath(cache._path)
+    parts = path.split(os.sep)
+    assert parts[-2] == "dirtest"
+    assert parts[-1] == "filetest.json"
+
+
+def test_WriteOnlyCredentialsCache_sets_path(module_under_test):
+    """ReadWriteCredentialsCache ctor should respect dirname and filename.
+
+    See: https://github.com/pydata/pydata-google-auth/issues/16
+    """
+    cache = module_under_test.WriteOnlyCredentialsCache(
+        dirname="dirtest", filename="filetest.json"
+    )
+    path = os.path.normpath(cache._path)
+    parts = path.split(os.sep)
+    assert parts[-2] == "dirtest"
+    assert parts[-1] == "filetest.json"


### PR DESCRIPTION
Previously, dirname and filename were ignored in the
ReadWriteCredentialsCache and WriteOnlyCredentialsCache constructors.

Closes #16.

/cc @Jonnyblacklabel