### PR TITLE
ENH: Add `authorized_user` to cached JSON files

### DIFF
--- a/pydata_google_auth/auth.py
+++ b/pydata_google_auth/auth.py
@@ -1,7 +1,6 @@
 """Private module for fetching Google API credentials."""
 
 import logging
-import warnings
 
 import google.auth
 import google.auth.exceptions

--- a/pydata_google_auth/cache.py
+++ b/pydata_google_auth/cache.py
@@ -111,6 +111,10 @@ def _save_user_account_credentials(credentials, credentials_path):
                 "client_id": credentials.client_id,
                 "client_secret": credentials.client_secret,
                 "scopes": credentials.scopes,
+                # Required for Application Default Credentials to detect the
+                # credentials type. See:
+                # https://github.com/pydata/pydata-google-auth/issues/22
+                "type": "authorized_user",
             }
             json.dump(credentials_json, credentials_file)
     except IOError:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -55,6 +55,11 @@ def test__save_user_account_credentials_wo_directory(module_under_test, fs):
         serialized_data = json.load(fp)
     assert serialized_data["refresh_token"] == "refresh_token"
 
+    # Set the type so that the cached credentials file can be used as
+    # application default credentials. See:
+    # https://github.com/pydata/pydata-google-auth/issues/22
+    assert serialized_data["type"] == "authorized_user"
+
 
 def test_ReadWriteCredentialsCache_sets_path(module_under_test):
     """ReadWriteCredentialsCache ctor should respect dirname and filename.


### PR DESCRIPTION
This allows cached files to be used as application default credentials.

Towards #22