### PR TITLE
ENH: Add save_user_credentials to write to JSON file.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,7 @@ API Reference
 
     default
     get_user_credentials
+    save_user_credentials
     cache.CredentialsCache
     cache.READ_WRITE
     cache.REAUTH

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,8 @@ Changelog
 
 - Deprecates ``auth_local_webserver`` argument in favor of
   ``use_local_webserver`` argument (:issue:`20`).
+- Adds :func:`pydata_google_auth.save_user_credentials` function to get user
+  credentials and then save them to a specified JSON path. (:issue:`22`)
 
 .. _changelog-0.1.3:
 

--- a/pydata_google_auth/__init__.py
+++ b/pydata_google_auth/__init__.py
@@ -1,5 +1,6 @@
 from .auth import default
 from .auth import get_user_credentials
+from .auth import save_user_credentials
 from ._version import get_versions
 
 versions = get_versions()
@@ -11,4 +12,10 @@ __git_revision__ = versions["full-revisionid"]
 This package provides helpers for fetching Google API credentials.
 """
 
-__all__ = ["__version__", "__git_revision__", "default", "get_user_credentials"]
+__all__ = [
+    "__version__",
+    "__git_revision__",
+    "default",
+    "get_user_credentials",
+    "save_user_credentials",
+]

--- a/pydata_google_auth/auth.py
+++ b/pydata_google_auth/auth.py
@@ -1,7 +1,6 @@
 """Private module for fetching Google API credentials."""
 
 import logging
-import os.path
 
 import google.auth
 import google.auth.exceptions

--- a/pydata_google_auth/auth.py
+++ b/pydata_google_auth/auth.py
@@ -1,6 +1,7 @@
 """Private module for fetching Google API credentials."""
 
 import logging
+import os.path
 
 import google.auth
 import google.auth.exceptions
@@ -266,3 +267,84 @@ def get_user_credentials(
         credentials.refresh(request)
 
     return credentials
+
+
+def save_user_credentials(
+    scopes, path, client_id=None, client_secret=None, use_local_webserver=False
+):
+    """
+    Gets user account credentials and saves them to a JSON file at ``path``.
+
+    This function authenticates using user credentials by going through the
+    OAuth 2.0 flow.
+
+    Parameters
+    ----------
+
+    scopes : list[str]
+        A list of scopes to use when authenticating to Google APIs. See the
+        `list of OAuth 2.0 scopes for Google APIs
+        <https://developers.google.com/identity/protocols/googlescopes>`_.
+    path : str
+        Path to save credentials JSON file.
+    client_id : str, optional
+        The client secrets to use when prompting for user credentials.
+        Defaults to a client ID associated with pydata-google-auth.
+
+        If you are a tool or library author, you must override the default
+        value with a client ID associated with your project. Per the `Google
+        APIs terms of service <https://developers.google.com/terms/>`_, you
+        must not mask your API client's identity when using Google APIs.
+    client_secret : str, optional
+        The client secrets to use when prompting for user credentials.
+        Defaults to a client secret associated with pydata-google-auth.
+
+        If you are a tool or library author, you must override the default
+        value with a client secret associated with your project. Per the
+        `Google APIs terms of service
+        <https://developers.google.com/terms/>`_, you must not mask your API
+        client's identity when using Google APIs.
+    use_local_webserver : bool, optional
+        Use a local webserver for the user authentication
+        :class:`google_auth_oauthlib.flow.InstalledAppFlow`. Defaults to
+        ``False``, which requests a token via the console.
+
+    Returns
+    -------
+
+    None
+
+    Raises
+    ------
+    pydata_google_auth.exceptions.PyDataCredentialsError
+        If unable to get valid user credentials.
+
+    Examples
+    --------
+
+    Get credentials for Google Cloud Platform and save them to
+    ``/home/username/keys/google-credentials.json``.
+
+    .. code-block:: python
+
+       pydata_google_auth.save_user_credentials(
+           ["https://www.googleapis.com/auth/cloud-platform"],
+           "/home/username/keys/google-credentials.json",
+           use_local_webserver=True,
+       )
+
+    Set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable to use
+    these credentials with Google Application Default Credentials.
+
+    .. code-block:: bash
+
+       export GOOGLE_APPLICATION_CREDENTIALS='/home/username/keys/google-credentials.json'
+    """
+    credentials = get_user_credentials(
+        scopes,
+        client_id=client_id,
+        client_secret=client_secret,
+        credentials_cache=cache.NOOP,
+        use_local_webserver=use_local_webserver,
+    )
+    cache._save_user_account_credentials(credentials, path)


### PR DESCRIPTION
This function is useful in combination with Google Application Default
credentials. Use this function to create a JSON key file for your user
credentials, which works similarly to a service account JSON key file in
combination with Google client libraries.

This is phase 1 of #22 