### PR TITLE
feat: add CLI for working with user credentials

### DIFF
--- a/ci/requirements-conda.txt
+++ b/ci/requirements-conda.txt
@@ -1,0 +1,3 @@
+setuptools
+google-auth
+google-auth-oauthlib

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,7 @@ API Reference
 
     default
     get_user_credentials
+    load_user_credentials
     save_user_credentials
     cache.CredentialsCache
     cache.READ_WRITE

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+.. _changelog-0.3.0:
+
+0.3.0 / (2020-02-04)
+--------------------
+
+- Add ``python -m pydata_google_auth`` CLI for working with user credentials.
+  (:issue:`28`)
+
 .. _changelog-0.2.1:
 
 0.2.1 / (2019-12-12)

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,88 @@
+Command-line Reference
+======================
+
+Run the ``pydata_google_auth`` CLI with ``python -m pydata_google_auth``.
+
+.. code:: bash
+
+   usage: python -m pydata_google_auth [-h] {login,print-token} ...
+
+   Manage credentials for Google APIs.
+
+   optional arguments:
+     -h, --help           show this help message and exit
+
+   commands:
+     {login,print-token}
+       login              Login to Google and save user credentials as a JSON
+                          file to use as Application Default Credentials.
+       print-token        Load a credentials JSON file and print an access token.
+
+
+Saving user credentials with ``login``
+--------------------------------------
+
+.. code:: bash
+
+   usage: python -m pydata_google_auth login [-h] [--scopes SCOPES]
+                                             [--client_id CLIENT_ID]
+                                             [--client_secret CLIENT_SECRET]
+                                             [--use_local_webserver]
+                                             destination
+
+   positional arguments:
+     destination           Path of where to save user credentials JSON file.
+
+   optional arguments:
+     -h, --help            show this help message and exit
+     --scopes SCOPES       Comma-separated list of scopes (permissions) to
+                           request from Google. See: https://developers.google.co
+                           m/identity/protocols/googlescopes for a list of
+                           available scopes. Default:
+                           https://www.googleapis.com/auth/cloud-platform
+     --client_id CLIENT_ID
+                           (Optional, but recommended) Client ID. Use this in
+                           combination with the --client-secret argument to
+                           authenticate with an application other than the
+                           default (PyData Auth). This argument is required to
+                           use APIs the track billing and quotas via the
+                           application (such as Cloud Vision), rather than
+                           billing the user (such as BigQuery does).
+     --client_secret CLIENT_SECRET
+                           (Optional, but recommended) Client secret. Use this in
+                           combination with the --client-id argument to
+                           authenticate with an application other than the
+                           default (PyData Auth). This argument is required to
+                           use APIs the track billing and quotas via the
+                           application (such as Cloud Vision), rather than
+                           billing the user (such as BigQuery does).
+     --use_local_webserver
+                           Use a local webserver for the user authentication.
+                           This starts a webserver on localhost, which allows the
+                           browser to pass a token directly to the program.
+
+Save credentials with Cloud Platform scope to ``~/keys/google-credentials.json``.
+
+.. code:: bash
+
+   python -m pydata_google_auth login ~/keys/google-credentials.json
+
+Loading user credentials with ``print-token``
+---------------------------------------------
+
+Print an access token associate with the credentials at
+``~/keys/google-credentials.json``.
+
+.. code:: bash
+
+   python -m pydata_google_auth print-token ~/keys/google-credentials.json
+
+Use ``curl`` and the ``credentials.json`` user credentials file to download
+the contents of ``gs://your-bucket/path/to/object.txt`` with the Google Cloud
+Storage JSON REST API.
+
+.. code:: bash
+
+   curl -X GET \
+       -H "Authorization: Bearer $(python -m pydata_google_auth print-token credentials.json)" \
+       "https://storage.googleapis.com/storage/v1/b/your-bucket/o/path%%2Fto%%2Fobject.txt?alt=media"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Contents:
 
    install.rst
    intro.rst
+   cli.rst
    api.rst
    contributing.rst
    changelog.rst

--- a/pydata_google_auth/__init__.py
+++ b/pydata_google_auth/__init__.py
@@ -1,5 +1,6 @@
 from .auth import default
 from .auth import get_user_credentials
+from .auth import load_user_credentials
 from .auth import save_user_credentials
 from ._version import get_versions
 
@@ -17,5 +18,6 @@ __all__ = [
     "__git_revision__",
     "default",
     "get_user_credentials",
+    "load_user_credentials",
     "save_user_credentials",
 ]

--- a/pydata_google_auth/__main__.py
+++ b/pydata_google_auth/__main__.py
@@ -1,0 +1,102 @@
+"""Private module that implements a pydata-google-auth CLI tool."""
+
+import argparse
+import sys
+
+from . import auth
+
+
+LOGIN_HELP = (
+    "Login to Google and save user credentials as a JSON file to use as "
+    "Application Default Credentials."
+)
+LOGIN_SCOPES_DEFAULT = "https://www.googleapis.com/auth/cloud-platform"
+LOGIN_SCOPES_HELP = (
+    "Comma-separated list of scopes (permissions) to request from Google. "
+    "See: https://developers.google.com/identity/protocols/googlescopes for "
+    "a list of available scopes. Default: {}"
+).format(LOGIN_SCOPES_DEFAULT)
+LOGIN_CLIENT_ID_HELP_TEMPLATE = (
+    "(Optional, but recommended) Client {}. Use this in combination with "
+    "the {other} argument to authenticate with an application other than the "
+    "default (PyData Auth). This argument is required to use APIs the track "
+    "billing and quotas via the application (such as Cloud Vision), rather "
+    "than billing the user (such as BigQuery does)."
+)
+LOGIN_CLIENT_ID_HELP = LOGIN_CLIENT_ID_HELP_TEMPLATE.format(
+    "ID", other="--client-secret"
+)
+LOGIN_CLIENT_SECRET_HELP = LOGIN_CLIENT_ID_HELP_TEMPLATE.format(
+    "secret", other="--client-id"
+)
+LOGIN_USE_LOCAL_WEBSERVER_HELP = (
+    "Use a local webserver for the user authentication. This starts "
+    "a webserver on localhost, which allows the browser to pass a token "
+    "directly to the program."
+)
+
+PRINT_TOKEN_HELP = "Load a credentials JSON file and print an access token."
+PRINT_TOKEN_DESCRIPTION = r"""examples:
+
+  Download the contents of gs://your-bucket/path/to/object.txt with the Google
+  Cloud Storage JSON REST API.
+
+    curl -X GET \
+        -H "Authorization: Bearer $(python -m pydata_google_auth print-token credentials.json)" \
+        "https://storage.googleapis.com/storage/v1/b/your-bucket/o/path%%2Fto%%2Fobject.txt?alt=media"
+"""
+
+
+def login(args):
+    scopes = args.scopes.split(",")
+    auth.save_user_credentials(
+        scopes,
+        args.destination,
+        client_id=args.client_id,
+        client_secret=args.client_secret,
+        use_local_webserver=args.use_local_webserver,
+    )
+
+
+def print_token(args):
+    credentials = auth.load_user_credentials(args.credentials_path)
+    print(credentials.token)
+
+
+parser = argparse.ArgumentParser(
+    prog="python -m pydata_google_auth",
+    description="Manage credentials for Google APIs.",
+)
+subparsers = parser.add_subparsers(title="commands", dest="command")
+
+login_parser = subparsers.add_parser("login", help=LOGIN_HELP)
+login_parser.add_argument(
+    "destination", help="Path of where to save user credentials JSON file."
+)
+login_parser.add_argument(
+    "--scopes", help=LOGIN_SCOPES_HELP, default=LOGIN_SCOPES_DEFAULT
+)
+login_parser.add_argument("--client_id", help=LOGIN_CLIENT_ID_HELP)
+login_parser.add_argument("--client_secret", help=LOGIN_CLIENT_SECRET_HELP)
+login_parser.add_argument(
+    "--use_local_webserver", action="store_true", help=LOGIN_USE_LOCAL_WEBSERVER_HELP
+)
+
+print_token_parser = subparsers.add_parser(
+    "print-token",
+    help=PRINT_TOKEN_HELP,
+    description=PRINT_TOKEN_DESCRIPTION,
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+print_token_parser.add_argument(
+    "credentials_path", help="Path of credentials JSON file."
+)
+
+args = parser.parse_args()
+if args.command == "login":
+    login(args)
+elif args.command == "print-token":
+    print_token(args)
+else:
+    print('Got unknown command "{}".'.format(args.command), file=sys.stderr)
+    parser.print_help()

--- a/pydata_google_auth/auth.py
+++ b/pydata_google_auth/auth.py
@@ -352,3 +352,46 @@ def save_user_credentials(
         use_local_webserver=use_local_webserver,
     )
     cache._save_user_account_credentials(credentials, path)
+
+
+def load_user_credentials(path):
+    """
+    Gets user account credentials from JSON file at ``path``.
+
+    Parameters
+    ----------
+    path : str
+        Path to credentials JSON file.
+
+    Returns
+    -------
+
+    google.auth.credentials.Credentials
+
+    Raises
+    ------
+    pydata_google_auth.exceptions.PyDataCredentialsError
+        If unable to load user credentials.
+
+    Examples
+    --------
+
+    Load credentials and use them to construct a BigQuery client.
+
+    .. code-block:: python
+
+       import pydata_google_auth
+       import google.cloud.bigquery
+
+       credentials = pydata_google_auth.load_user_credentials(
+           "/home/username/keys/google-credentials.json",
+       )
+       client = google.cloud.bigquery.BigQueryClient(
+           credentials=credentials,
+           project="my-project-id"
+       )
+    """
+    credentials = cache._load_user_credentials_from_file(path)
+    if not credentials:
+        raise exceptions.PyDataCredentialsError("Could not load credentials.")
+    return credentials

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -8,14 +8,22 @@ except ImportError:  # pragma: NO COVER
 import google.auth
 import google.auth.credentials
 import google.oauth2.credentials
+import pytest
+
+from pydata_google_auth import exceptions
 
 
 TEST_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 
 
-def test_default_returns_google_auth_credentials(monkeypatch):
+@pytest.fixture
+def module_under_test():
     from pydata_google_auth import auth
 
+    return auth
+
+
+def test_default_returns_google_auth_credentials(monkeypatch, module_under_test):
     def mock_default_credentials(scopes=None, request=None):
         return (
             mock.create_autospec(google.auth.credentials.Credentials),
@@ -24,13 +32,12 @@ def test_default_returns_google_auth_credentials(monkeypatch):
 
     monkeypatch.setattr(google.auth, "default", mock_default_credentials)
 
-    credentials, project = auth.default(TEST_SCOPES)
+    credentials, project = module_under_test.default(TEST_SCOPES)
     assert project == "default-project"
     assert credentials is not None
 
 
-def test_default_loads_user_credentials(monkeypatch):
-    from pydata_google_auth import auth
+def test_default_loads_user_credentials(monkeypatch, module_under_test):
     from pydata_google_auth import cache
 
     def mock_default_credentials(scopes=None, request=None):
@@ -42,6 +49,13 @@ def test_default_loads_user_credentials(monkeypatch):
     mock_user_credentials = mock.create_autospec(google.oauth2.credentials.Credentials)
     mock_cache.load.return_value = mock_user_credentials
 
-    credentials, project = auth.default(TEST_SCOPES, credentials_cache=mock_cache)
+    credentials, project = module_under_test.default(
+        TEST_SCOPES, credentials_cache=mock_cache
+    )
     assert project is None
     assert credentials is mock_user_credentials
+
+
+def test_load_user_credentials_raises_when_file_doesnt_exist(module_under_test):
+    with pytest.raises(exceptions.PyDataCredentialsError):
+        module_under_test.load_user_credentials("path/not/found.json")


### PR DESCRIPTION
The CLI is run with `python -m pydata_google_auth`. It
contains a "login" command, which saves a user credentials
JSON file (usable with `GOOGLE_APPLICATION_CREDENTIALS`).
It also contains a "print-token" command, which is useful
for generating an access token from a user credentials
JSON file.

Examples:

Save credentials with Cloud Platform scope to `~/keys/google-credentials.json`.

    python -m pydata_google_auth login ~/keys/google-credentials.json

Download the contents of `gs://your-bucket/path/to/object.txt` with the Google
Cloud Storage JSON REST API.

    curl -X GET \
        -H "Authorization: Bearer $(python -m pydata_google_auth print-token credentials.json)" \
        "https://storage.googleapis.com/storage/v1/b/your-bucket/o/path%%2Fto%%2Fobject.txt?alt=media"