### PR TITLE
fix: don't raise error when APPDATA isn't set

### DIFF
--- a/pydata_google_auth/cache.py
+++ b/pydata_google_auth/cache.py
@@ -25,9 +25,11 @@ def _get_default_credentials_path(credentials_dirname, credentials_filename):
     str
         Path to the Google user credentials
     """
+    config_path = None
+
     if os.name == "nt":
-        config_path = os.environ["APPDATA"]
-    else:
+        config_path = os.getenv("APPDATA")
+    if not config_path:
         config_path = os.path.join(os.path.expanduser("~"), ".config")
 
     config_path = os.path.join(config_path, credentials_dirname)

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -34,6 +34,19 @@ def test_import_unwriteable_fs(module_under_test, monkeypatch):
     assert module_under_test.NOOP is not None
 
 
+def test__get_default_credentials_path_windows_wo_appdata(
+    module_under_test, monkeypatch
+):
+    # Ensure default path returns something sensible on Windows, even if
+    # APPDATA is not set. See:
+    # https://github.com/pydata/pydata-google-auth/issues/29
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    creds_path = module_under_test._get_default_credentials_path("dirname", "filename")
+    assert creds_path is not None
+
+
 def test__save_user_account_credentials_wo_directory(module_under_test, fs):
     """Directories should be created if they don't exist."""
 


### PR DESCRIPTION
There are Windows machines without an APPDATA environment variable. Use
the `expanduser` logic for the default config path in this case.

Closes #29.