### PR TITLE
doc: fix links to google-auth libraries

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -37,5 +37,5 @@ Dependencies
 
 This module requires following additional dependencies:
 
-- `google-auth <https://github.com/GoogleCloudPlatform/google-auth-library-python>`__: authentication and authorization for Google's API
-- `google-auth-oauthlib <https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib>`__: integration with `oauthlib <https://github.com/idan/oauthlib>`__ for end-user authentication
+- `google-auth <https://github.com/googleapis/google-auth-library-python>`__: authentication and authorization for Google's API
+- `google-auth-oauthlib <https://github.com/googleapis/google-auth-library-python-oauthlib>`__: integration with `oauthlib <https://github.com/idan/oauthlib>`__ for end-user authentication


### PR DESCRIPTION
Libraries moved from GoogleCloudPlatform to googleapis