### PR TITLE
test: fix flake in `test_webserver`

### DIFF
--- a/tests/unit/test_webserver.py
+++ b/tests/unit/test_webserver.py
@@ -56,7 +56,7 @@ def test_run_local_server_calls_flow(monkeypatch, module_under_test):
         google_auth_oauthlib.flow.InstalledAppFlow, instance=True
     )
     module_under_test.run_local_server(mock_flow)
-    mock_flow.run_local_server.assert_called_once_with(host="localhost", port=8080)
+    mock_flow.run_local_server.assert_called_once_with(host="localhost", port=mock.ANY)
 
 
 def test_run_local_server_raises_connectionerror(monkeypatch, module_under_test):


### PR DESCRIPTION
Since the real `find_open_port` runs, the requested port
might not always be 8080. For example, this test was
consistently failing when running `pytest tests` because
the unit tests were running after the system tests, making
the requested port 8082.

Follow-up to #35