### PR TITLE
doc: fix inconsequential "credentails" typo

### DIFF
--- a/pydata_google_auth/auth.py
+++ b/pydata_google_auth/auth.py
@@ -177,7 +177,7 @@ def get_user_credentials(
     ``PyData Google Auth``. The permissions it requests correspond to the
     scopes you've provided.
 
-    Additional information on the user credentails authentication mechanism
+    Additional information on the user credentials authentication mechanism
     can be found `here
     <https://developers.google.com/identity/protocols/OAuth2#clientside/>`__.
 


### PR DESCRIPTION
Just a nitpicking-level typo fix: `credentails` ➔ `credentials` on the **auth.get_user_credentials** docstring.