### PR TITLE
fix: avoid deprecated "out-of-band" authentication flow

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. _changelog-1.4.0:
+
+1.4.0 / (TBD)
+-------------
+
+- Set ``use_local_webserver`` to ``True`` because of `Google's "out of band"
+  authentication flow deprecation
+  <https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html?m=1#disallowed-oob>`_.
+
 .. _changelog-1.3.0:
 
 1.3.0 / (2021-12-03)

--- a/pydata_google_auth/__main__.py
+++ b/pydata_google_auth/__main__.py
@@ -55,7 +55,7 @@ def login(args):
         args.destination,
         client_id=args.client_id,
         client_secret=args.client_secret,
-        use_local_webserver=args.use_local_webserver,
+        use_local_webserver=not args.nouse_local_webserver,
     )
 
 
@@ -80,7 +80,12 @@ login_parser.add_argument(
 login_parser.add_argument("--client_id", help=LOGIN_CLIENT_ID_HELP)
 login_parser.add_argument("--client_secret", help=LOGIN_CLIENT_SECRET_HELP)
 login_parser.add_argument(
-    "--use_local_webserver", action="store_true", help=LOGIN_USE_LOCAL_WEBSERVER_HELP
+    "--use_local_webserver",
+    action="store_true",
+    help="Ignored. Defaults to true. To disable, set --nouse_local_webserver option.",
+)
+login_parser.add_argument(
+    "--nouse_local_webserver", action="store_true", help=LOGIN_USE_LOCAL_WEBSERVER_HELP
 )
 
 print_token_parser = subparsers.add_parser(

--- a/pydata_google_auth/auth.py
+++ b/pydata_google_auth/auth.py
@@ -27,7 +27,7 @@ def default(
     client_id=None,
     client_secret=None,
     credentials_cache=cache.READ_WRITE,
-    use_local_webserver=False,
+    use_local_webserver=True,
     auth_local_webserver=None,
 ):
     """
@@ -161,7 +161,7 @@ def get_user_credentials(
     client_id=None,
     client_secret=None,
     credentials_cache=cache.READ_WRITE,
-    use_local_webserver=False,
+    use_local_webserver=True,
     auth_local_webserver=None,
 ):
     """
@@ -279,7 +279,7 @@ def get_user_credentials(
 
 
 def save_user_credentials(
-    scopes, path, client_id=None, client_secret=None, use_local_webserver=False
+    scopes, path, client_id=None, client_secret=None, use_local_webserver=True
 ):
     """
     Gets user account credentials and saves them to a JSON file at ``path``.


### PR DESCRIPTION
The console-based copy-paste-a-token flow has been deprecated. See:
https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html?m=1#disallowed-oob