### PR TITLE
chore: release 1.8.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. _changelog-1.8.0:
+
+1.8.0 / (2023-05-09)
+--------------------
+
+- When running on Google Colab, try Colab-based authentication
+  (``google.colab.auth.authenticate_user()``) before attempting the Google
+  Application Default Credentials flow. (:issue:`68`)
+
 .. _changelog-1.7.0:
 
 1.7.0 / (2023-02-07)

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -24,6 +24,16 @@ User credentials
 Use the :func:`pydata_google_auth.get_user_credentials` to get user
 credentials, authenticated to Google APIs.
 
+By default, pydata-google-auth will listen for the credentials on a local
+webserver, which is used as the redirect page from Google's OAuth 2.0 flow.
+When you set ``use_local_webserver=False``, pydata-google-auth will request
+that you copy a token from the :ref:`oauth-sign-in` page.
+
+.. toctree::
+   :maxdepth: 2
+
+   oauth.rst
+
 Default credentials
 -------------------
 

--- a/docs/source/oauth.rst
+++ b/docs/source/oauth.rst
@@ -2,6 +2,9 @@
    :alt: pydata logo
    :class: logo
 
+
+.. _oauth-sign-in:
+
 Sign in to BigQuery
 ===================
 

--- a/pydata_google_auth/auth.py
+++ b/pydata_google_auth/auth.py
@@ -165,7 +165,7 @@ def _ensure_application_default_credentials_in_colab_environment():
         from google.colab import auth
 
         auth.authenticate_user()
-    except (ModuleNotFoundError, ImportError):
+    except ImportError:
         pass
 
 


### PR DESCRIPTION
Also:

* fix(python2.7): remove reference to ModuleNotFoundError which is not present in Python 2.7. Also, it is unnecessary, since it is a subclass of ImportError.
* docs: add OAuth page to docs table-of-contents to fix Sphinx error