### PR TITLE
Do not require six on Python 3

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,11 @@
 Changelog
 =========
+.. _changelog-1.8.3:
+
+1.8.3 / (future)
+----------------
+
+- Clean up remaining uses of six (:issue:`73`)
 
 .. _changelog-1.8.2:
 

--- a/pydata_google_auth/auth.py
+++ b/pydata_google_auth/auth.py
@@ -40,7 +40,6 @@ AUTH_URI_KWARGS = {
 
 
 def _run_webapp(flow, redirect_uri=None, **kwargs):
-
     if redirect_uri:
         flow.redirect_uri = redirect_uri
     else:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -7,6 +7,7 @@ import os.path
 import pytest
 
 import google.oauth2.credentials
+
 try:
     from importlib import reload
 except ImportError: # Py2 compat

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -10,7 +10,8 @@ import google.oauth2.credentials
 
 try:
     from importlib import reload
-except ImportError: # Py2 compat
+
+except ImportError:  # Py2 compat
     from six.moves import reload_module as reload
 
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -7,7 +7,10 @@ import os.path
 import pytest
 
 import google.oauth2.credentials
-from six.moves import reload_module
+try:
+    from importlib import reload
+except ImportError: # Py2 compat
+    from six.moves import reload_module as reload
 
 
 @pytest.fixture
@@ -29,7 +32,7 @@ def test_import_unwriteable_fs(module_under_test, monkeypatch):
     monkeypatch.setattr(os.path, "exists", lambda _: False)
     monkeypatch.setattr(os, "makedirs", raise_unwriteable)
 
-    reload_module(module_under_test)
+    reload(module_under_test)
 
     assert module_under_test.NOOP is not None
 


### PR DESCRIPTION
Python 2.7 is dead for quite some time and there are Python3-only operating systems out there. There is no need to require six on those systems.

Preserved backwards compatibility if you want it.